### PR TITLE
updated date strings to fix some fringe case bugs

### DIFF
--- a/save.js
+++ b/save.js
@@ -4,10 +4,10 @@ var canSave = 1;
 // Saves the game by writing play to JSON and save it in localStorage
 var save = function(){
 	var date = new Date();
-	if(date.getDate() !== player.lastSeen){
+	if(date.toDateString() !== player.lastSeen){
 		dailyReset();
 	}
-	player.lastSeen = new Date().getDate();
+	player.lastSeen = new Date().toDateString();
 	if(canSave){
 		localStorage.setItem("player", JSON.stringify(player));
 	}
@@ -82,7 +82,7 @@ var load = function(){
 	}
 
 	var date = new Date();
-	if(date.getDate() !== player.lastSeen){
+	if(date.toDateString() !== player.lastSeen){
 		dailyReset();
 	}
 


### PR DESCRIPTION
new Date.getDate() only returns an integer (1-31) describing the day of the month. This could have caused minor issues if a player stopped playing for exactly one month or one year. Using the full date string (i.e. "Thu Oct 06 2016") will resolve this issue and be more robust.

This will also have a side effect of giving everyone a free new quest on the day this change goes live...but whatever.
