### PR TITLE
Fixed unlimited dungeon bug

### DIFF
--- a/dungeons.js
+++ b/dungeons.js
@@ -376,20 +376,22 @@ var dungeonEnemyDefeated = function() {
         $("#dungeonCatchDisplay").html("Catch chance: " + Math.min(100, catchRate) + "%");
         progressEgg(Math.floor(Math.sqrt(currentDungeon.itemRoute)));
         setTimeout(function() {
-            if (canCatch) {
+            if (inProgress != 0) {
+                if (canCatch) {
 
-                var chance = Math.floor(Math.random() * 100 + 1);
-                if (chance <= catchRate) {
-                    capturePokemon(curEnemy.name, curEnemy.shiny);
+                    var chance = Math.floor(Math.random() * 100 + 1);
+                    if (chance <= catchRate) {
+                        capturePokemon(curEnemy.name, curEnemy.shiny);
 
+                    }
+                    updateStats();
                 }
-                updateStats();
-            }
-            currentDungeon.pokemonDefeated++
-            updateDungeon();
-            // hideDungeonEnemy();
-            if(bossDefeated()){
-                dungeonDefeated();
+                currentDungeon.pokemonDefeated++
+                updateDungeon();
+                // hideDungeonEnemy();
+                if(bossDefeated()){
+                    dungeonDefeated();
+                }
             }
         }, player.catchTime);
         curEnemy.alive = false;


### PR DESCRIPTION
This was caused by updateDungeon() being called after dungeonTimer() had cleared the interval.

This will also stop pokemon being caught and the dungeon being completed if time runs out while catching is happening, I'm not sure whether you want the dungeon to count as completed or not if it is the Boss being caught.