### PR TITLE
Track time played and date started

### DIFF
--- a/save.js
+++ b/save.js
@@ -11,6 +11,10 @@ var save = function(){
 	if(canSave){
 		localStorage.setItem("player", JSON.stringify(player));
 	}
+
+	var tmp = new Date().getTime();
+	player.timePlayed += tmp - player.lastSaved;
+	player.lastSaved = tmp;
 }
 
 
@@ -25,6 +29,7 @@ var load = function(){
 	}
 
 	player.route = Math.min(25,player.route);
+	player.lastSaved = new Date().getTime();
 
     if(player.starter === "none"){
         $("#pickStarter").modal('show');

--- a/system.js
+++ b/system.js
@@ -89,6 +89,9 @@ var player = {
 	oakItemsEquipped: [],
 	gymsDefeated: Array.apply(null, Array(15)).map(Number.prototype.valueOf,0),
 	dungeonsDefeated: Array.apply(null, Array(15)).map(Number.prototype.valueOf,0),
+	dateStarted: new Date(),
+	timePlayed: 0,
+	lastSaved: new Date().getTime(),
 }
 
 var curEnemy = {


### PR DESCRIPTION
On loading the page, a new Date() is created and set as dateStarted, and this is replaced if savegame contains dateStarted.

Total time spent playing is updated in save(), lastSaved is updated on load so that time spent with the game closed is not counted.