### PR TITLE
Rework keypress handling, toggle animation instead

### DIFF
--- a/safari.js
+++ b/safari.js
@@ -27,6 +27,13 @@ var safari = {
     catchFactor: 0,
     angry: 0,
     },
+    frame: 0,
+    walking: {
+        up: 0,
+        right: 0,
+        left: 0,
+        down: 0,
+    },
 }
 
 var element;
@@ -134,12 +141,13 @@ var showSafari = function(){
 }
 
 
-var safariStep = function(direction, frame) {
+var safariStep = function(direction) {
     safari.lastDirection = direction;
 
-    sprite.to(frame,true)
-    frame = (frame+2)%4;
-    sprite.to(frame);
+    //sprite.to(safari.frame,true);
+    //frame = (frame+2)%4;
+    //sprite.to(frame);
+    sprite.toggle();
     directionOffset = getXY(direction);
     safari.movingX = directionOffset.x;
     safari.movingY = directionOffset.y;
@@ -158,12 +166,11 @@ var safariStep = function(direction, frame) {
         safari.player.y += safari.movingY;
         $('#sprite').animate(safari.offset, 250, "linear", function() {
             safari.isMoving = 0;
-            if(walking){ if (!checkBattle()){safariStep(safari.nextDirection,frame)} }
+            if(walking){ if (!checkBattle()){safariStep(safari.nextDirection)} }
         });
     } else {
-        walking = true;
         $(".sprite").css("background", "url('images/safari/walk"+direction+".png')");
-        sprite.toStart(function(){walking = false});
+        sprite.toStart();
         safari.isMoving = 0;
     }
 }
@@ -222,8 +229,18 @@ var safariMove = function(direction){
         sprite = new Motio(element, {
             fps: 8,
             frames: 4
+        }).on('frame', function() {
+            if (sprite.frame%2 == 0) {
+                sprite.pause();
+                safari.frame = sprite.frame;
+            }
         });
-        safariStep(direction, frame);
+        if (safari.frame == 2) {
+            sprite.to(2, true, function(){safariStep(direction)});
+        }
+        else {
+            safariStep(direction);
+        }
         
         safari.lastDirection = direction;
     }

--- a/system.js
+++ b/system.js
@@ -344,15 +344,19 @@ $(document).ready(function(){
 			if(!walking && !safari.isMoving) {
 				if(keyCode == 38 || keyCode == 87){
 					walking = true;
+					safari.walking.up = 1;
 					safariMove('up');
 				} else if(keyCode == 39 || keyCode == 68){
 					walking = true;
+					safari.walking.right = 1;
 					safariMove('right');
 				} else if(keyCode == 37 || keyCode == 65){
 					walking = true;
+					safari.walking.left = 1;
 					safariMove('left');
 				} else if(keyCode == 40 || keyCode == 83){
 					walking = true;
+					safari.walking.down = 1;
 					safariMove('down');
 				} else if(keyCode == 32){
 				}
@@ -374,17 +378,25 @@ $(document).ready(function(){
 	$(document).on("keyup", function (e) {
 		var keyCode = e.keyCode;
 		if(inProgress == 4){
+			var tmp = 0;
+			for (dir in safari.walking) {
+				tmp += safari.walking[dir];
+			};
 			if(keyCode == 38 || keyCode == 87){
-				if(safari.nextDirection == safari.lastDirection){walking = false};
+				safari.walking.up = 0;
+				if (tmp == 1){ walking = false };
 				e.preventDefault();
 			} else if(keyCode == 39 || keyCode == 68){
-				if(safari.nextDirection == safari.lastDirection){walking = false};
+				safari.walking.right = 0;
+				if (tmp == 1){ walking = false };
 				e.preventDefault();
 			} else if(keyCode == 37 || keyCode == 65){
-				if(safari.nextDirection == safari.lastDirection){walking = false};
+				safari.walking.left = 0;
+				if (tmp == 1){ walking = false };
 				e.preventDefault();
 			} else if(keyCode == 40 || keyCode == 83){
-				if(safari.nextDirection == safari.lastDirection){walking = false};
+				safari.walking.down = 0;
+				if (tmp == 1){ walking = false };
 				e.preventDefault();
 			} else if(keyCode == 32){
 				e.preventDefault();
@@ -482,6 +494,7 @@ $(document).ready(function(){
 var setNextDirection = function(direction) {
 	if(direction != safari.lastDirection){
 		safari.nextDirection = direction;
+		safari.walking[direction] = 1;
 		walking = true;
 	}
 }


### PR DESCRIPTION
Now keeps track of all directional keys held, walking only set to false (and hence ending the current walk) once the last one is released.

Now uses Motio .on('frame') to handle only moving forward two frames per step, and the current frame is kept track of in safari.frame so that when a new Motio object is created, it can be started from the correct frame.