### PR TITLE
Center shiny's in the stone evolve menu instead of scaling them

### DIFF
--- a/system.css
+++ b/system.css
@@ -573,8 +573,8 @@ table, #console, #currentEnemy, #upgradeBox, #navBar, #townView, #gymView, #shop
 }
 
 .largeShinyImage{
-	height: 96px;
-	width: auto;
+	padding-top: 17px;
+	padding-bottom: 17px;
 }
 
 .smallShinyImage{


### PR DESCRIPTION
This will change this:
![picca](http://imgur.com/tHJz1v6.png)

To this:
![picca2](http://imgur.com/ibifm7y.png)