### PR TITLE
Check for longer deal loops

### DIFF
--- a/mining.js
+++ b/mining.js
@@ -27,12 +27,16 @@ var generateDailyDeals = function(){
 }
 
 var reverseDailyDealExists = function(item1, item2){
-    for(var i = 0; i<player.curMine.dailyDeals.length; i++){
-        if(player.curMine.dailyDeals[i].item1.name === item2.name && player.curMine.dailyDeals[i].item2.name === item1.name){
-            return true;
-        }
-    }
-    return false;
+	for (var i=0; i<player.curMine.dailyDeals.length; i++) {
+		if (player.curMine.dailyDeals[i].item2.name == item1.name) {
+			if (player.curMine.dailyDeals[i].item1.name == item2.name) {
+				return true;
+			}else {
+				return reverseDeal(player.curMine.dailyDeals[i].item1, item2);
+			}
+		}
+	}
+	return false
 }
 
 var generateDailyDeal = function(seed){

--- a/mining.js
+++ b/mining.js
@@ -32,7 +32,7 @@ var reverseDailyDealExists = function(item1, item2){
 			if (player.curMine.dailyDeals[i].item1.name == item2.name) {
 				return true;
 			}else {
-				return reverseDeal(player.curMine.dailyDeals[i].item1, item2);
+				return reverseDailyDealExists(player.curMine.dailyDeals[i].item1, item2);
 			}
 		}
 	}


### PR DESCRIPTION
This does the same as before, but now if it finds two deals like  a->b  b->c  it will check for a loop with the consolidated deal a->c

This is to prevent loops like
a->b
b->c
c->a
being allowed to happen. 