### PR TITLE
check for item.quantity before using an evo stone

### DIFF
--- a/items.js
+++ b/items.js
@@ -275,10 +275,12 @@ var useEvoStone = function(item){
 }
 
 var activateEvoStone = function(pokemon, id){
-	capturePokemon(pokemon, generateStoneShiny());
 	var item = player.inventoryList[getItemById(id)];
-	item.quantity--;
-	updateItems();
+	if (item.quantity > 0){
+		capturePokemon(pokemon, generateStoneShiny());
+		item.quantity--;
+		updateItems();
+	}
 }
 
 var generateStoneShiny = function(){


### PR DESCRIPTION
Fix to #131 

Checks item.quantity > 0 before using an evo stone. The same check is already in place for other item types.