### PR TITLE
Fix gym pokemon on routes

### DIFF
--- a/map.js
+++ b/map.js
@@ -68,16 +68,18 @@ var moveToRoute = function(route){
 
 	
 		if(!isNaN(route) && !(route == player.route && inProgress === 1)){
-			inProgress = 1;
 			hideAllViews()
 			resetDungeon();
 			$("#currentEnemy").show();
 			if(accessToRoute(route)){
 				player.route = route;
-				generatePokemon(player.route);
 			}
 			else {
 				log("You don't have access to that route yet.");
+			}
+			if(accessToRoute(route) || inProgress !== 1){
+				inProgress = 1;
+				generatePokemon(player.route);
 			}
 		}
 	


### PR DESCRIPTION
It was possible to capture gym pokemon by attempting to access a route you were not able to go to yet, during a gym battle. The same thing happened with dungeon pokemon, but you could already catch those anyway.