### PR TITLE
Remove extra .dungeonCatchDisplay element

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,7 +156,6 @@
 	                        <div id="chestInfo"></div>
 	                    </div>
                         <div class="dungeonProgress progress" id='dungeonProgress'>
-	                        <span id="dungeonCatchDisplay"></span>
                         	<span id="dungeonHealthDisplay"></span>
                             <div class="progress-bar progress-bar-danger" id="dungeonHealthBar" style="width: 100%">
                                 <span class="sr-only"></span>


### PR DESCRIPTION
I'm pretty sure this is what was causing the bug where sometimes you would have a catch chance showing inside of the health bar during a dungeon (which didn't go away until you refresh the page).

The catch chance which is normally shown is inside of dungeonEnemyInfo. The one I removed is usually hidden when the catch chance is set so it is always blank, except for the times when it doesn't get hidden fast enough. At least I think that is what was happening.

You can recreate the permanent catch display thing easily with the bug mentioned in #139, in case you haven't seen it before.