### PR TITLE
Small mineSquare outline changes

### DIFF
--- a/system.css
+++ b/system.css
@@ -59,10 +59,20 @@
 	right: 0;
 }
 
-.mineSquare:hover:after {
+.rock1:hover:after,
+.rock2:hover:after,
+.rock3:hover:after,
+.rock4:hover:after,
+.rock5:hover:after,
+.hammerSelected.mineSquare:hover:after
+{
 	border: 1px solid red;
 }
 
+img.hammerSelected.mineReward:hover {
+	outline: 1px solid red;
+	z-index: 1;
+}
 
 .hammerSelected {
 	cursor:url('images/mine/hammer.png'),auto;


### PR DESCRIPTION
To fix #56 

Empty squares no longer get the border when you are using the chisel, and the hammer gets a border on everything since you might be clearing out the spaces around a cleared square. I tried making the hammer border 3x3, but I was having issues getting it to switch over to the next square when moving to the top or left.