### PR TITLE
Remove classes 'active' and 'in' from #statsTab

### DIFF
--- a/index.html
+++ b/index.html
@@ -963,7 +963,7 @@
 											</div>
 										</div>
 									</div>
-									<div id="statsTab" class="tab-pane fade active in">
+									<div id="statsTab" class="tab-pane fade">
 										<div id="statsBody" style="width:80%; margin:auto; margin-top:30px; text-align:center"></div>
 									</div>
 								</div>


### PR DESCRIPTION
These were making the stats info load into the pokedex modal before changing to it's tab. You can confirm by just refreshing the page (to reset the classes to what is in index.html) and then opening the pokedex and scrolling down.