### PR TITLE
Fix gap at right of map

### DIFF
--- a/index.html
+++ b/index.html
@@ -181,7 +181,7 @@
 								</lineargradient>
 							</defs>
 							<g transform="translate(-1,-1)">
-								<image height="420.7" width="650" xlink:href="images/kanto_Map.png" ></image>
+								<image height="420.7" width="651" xlink:href="images/kanto_Map.png" ></image>
 								<rect id="route_3" fill="#fcb612" height="28" id="route_3" stroke="none" width="112.1" x="92.3" y="100.1"></rect>
 								<g id="route_3" transform="translate(128.5,106.5)scale(0.7)">
 									<switch>
@@ -287,7 +287,7 @@
 										</text>
 									</switch>
 								</g>
-								<rect id="route_16" fill="#fcb612" height="28" stroke="none" width="115" x="149.9" y="153.3"></rect>
+								<rect id="route_16" fill="#fcb612" height="28" stroke="none" width="115" x="148.9" y="153.3"></rect>
 								<g id="route_16" transform="translate(178.5,160.5)scale(0.7)">
 									<switch>
 										<foreignobject height="19" pointer-events="all" requiredfeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;" width="74">
@@ -332,7 +332,7 @@
 										</text>
 									</switch>
 								</g>
-								<rect id="route_17" fill="#0412d9" height="27.3" stroke="none" transform="rotate(90,163.45,262.15)" width="162.7" x="81.6" y="248.5"></rect>
+								<rect id="route_17" fill="#0412d9" height="27.3" stroke="none" transform="rotate(90,163.45,262.15)" width="162.7" x="81.6" y="249.5"></rect>
 
 								<g id="route_17" transform="translate(137.5,255.5)scale(0.7)rotate(90,36.5,9.5)">
 									<switch>
@@ -438,7 +438,7 @@
 										</text>
 									</switch>
 								</g>
-								<rect id="route_12" fill="#fcb612" height="28" stroke="none" transform="rotate(90,458.85,219.8)" width="80.5" x="418.6" y="207.8"></rect>
+								<rect id="route_12" fill="#fcb612" height="28" stroke="none" transform="rotate(90,458.85,219.8)" width="80.5" x="418.6" y="206.8"></rect>
 								<g id="route_12" transform="translate(431.5,212.5)scale(0.7)rotate(90,38.5,10)">
 									<switch>
 										<foreignobject height="20" pointer-events="all" requiredfeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;" width="77">
@@ -520,7 +520,7 @@
 										</text>
 									</switch>
 								</g>
-								<rect id="route_21"  fill="#0412d9" height="28" stroke="none" transform="rotate(90,83.65,340.2)" width="60.7" x="55.3" y="326.2"></rect>
+								<rect id="route_21"  fill="#0412d9" height="28" stroke="none" transform="rotate(90,83.65,340.2)" width="60.7" x="55.3" y="327.2"></rect>
 								<g id="route_21" transform="translate(57.5,333.5)scale(0.7)rotate(90,36.5,9.5)">
 									<switch>
 										<foreignobject height="19" pointer-events="all" requiredfeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;" width="73">


### PR DESCRIPTION
There is a 1 pixel gap between the map and the right border currently.

Changes to some \<rect> co-ordinates is to fix a couple of alignment issues that increasing the map width introduces.