### PR TITLE
Only force close evoModal when all stones have been used

### DIFF
--- a/items.js
+++ b/items.js
@@ -278,9 +278,13 @@ var useEvoStone = function(item){
 var activateEvoStone = function(pokemon, id){
 	var item = player.inventoryList[getItemById(id)];
 	if (item.quantity > 0){
-		capturePokemon(pokemon, generateStoneShiny());
+		var shiny = generateStoneShiny();
+		capturePokemon(pokemon, shiny);
 		item.quantity--;
 		updateItems();
+		if (shiny){
+			$("#evoModal div[data-pokemon='"+pokemon+"'] > #alreadyCaughtImage").attr('src', "images/shinyPokeball.PNG");
+		}
 		if (item.quantity == 0){
 			$("#evoModal").modal("hide");
 		} else {

--- a/items.js
+++ b/items.js
@@ -271,7 +271,7 @@ var useEvoStone = function(item){
 	html += "</div>";
 
 	$("#evoBody").html(html);
-	$("#evoTitle").html(item.name);
+	$("#evoTitle").html(item.name + " (" + player.inventoryList[getItemById(item.id)].quantity + ")");
 	updateItems();
 }
 
@@ -281,6 +281,11 @@ var activateEvoStone = function(pokemon, id){
 		capturePokemon(pokemon, generateStoneShiny());
 		item.quantity--;
 		updateItems();
+		if (item.quantity == 0){
+			$("#evoModal").modal("hide");
+		} else {
+			$("#evoTitle").html(item.name + " (" + item.quantity + ")");
+		}
 	}
 }
 

--- a/system.js
+++ b/system.js
@@ -412,7 +412,6 @@ $(document).ready(function(){
 
 	$("body").on('click',".evoButton", function(){
 		activateEvoStone(this.dataset.pokemon, this.id.substr(3));
-		$("#evoModal").modal("hide");
 	})
 
 	$("body").on('click',".breedPokemon", function(){


### PR DESCRIPTION
Using lots of stones (easily gained from underground) it can be very time consuming because the modal will close immediately. This will show the number of stones you have left in the title of the modal, and only close it once you have used all of the stones. The modal can still be closed by clicking the background as with other modals.