### PR TITLE
Disable shard upgrade buttons if player doesn't have enough shards

### DIFF
--- a/types.js
+++ b/types.js
@@ -271,7 +271,7 @@ var buyVeryUpgrade = function(type){
 var showShardModal = function(){
 	$("#shardModal").modal("show");
 	var html = ""
-	for(var i = 0; i<18; i++){
+	for(var i = 0; i < player.typeShards.length; i++){
 		html += "<table class=shardTable>";
 		html += "<tr> <td style='width:15%'>" +numberToType[i] + "</td><td>Not very effective:</td>";
 		html +=	"<td>" + getNotEffective(i).toFixed(2) + "x</td>";
@@ -283,33 +283,43 @@ var showShardModal = function(){
 			html += "<div style='background-color:#" + typeColorLocked[i] + "' class='col-sm-1 shardUpgrade shardUpgradeLocked'></div>";	
 		}
 		
-		html += "<td class='shardColumn4'>";
+		html += "</td><td class='shardColumn4'>";
 		if (player.notEffectiveTypeBonus[i] < 10){
-			html += "<button class='tooltipShard' title='" + numberWithCommas(250*(player.notEffectiveTypeBonus[i]+1)) + " " + numberToType[i] + " shards' onclick='buyUpgrade("+ i + "," + 1 +")'>Upgrade</button>";
+			var cost = 250*(player.notEffectiveTypeBonus[i]+1);
+			if (player.typeShards[i] >= cost){
+				html += "<button class='tooltipShard' title='" + numberWithCommas(cost) + " " + numberToType[i] + " shards' onclick='buyUpgrade("+ i + "," + 1 +")'>Upgrade</button>";
+			} else {
+				html += "<button class='tooltipShard' title='" + numberWithCommas(cost) + " " + numberToType[i] + " shards' onclick='buyUpgrade("+ i + "," + 1 +")' disabled>Upgrade</button>";
+			}
 		} else {
 			html += "<button class='disabled'>Upgrade</button>";
 		}
 
-		html += "</td></td></tr>";
+		html += "</td></tr>";
 
 		html +="<tr><td><img class= shardImage' id='normalShard' src='images/shards/" + i + ".png'> " + numberWithCommas(player.typeShards[i]) + "</td>";
 		html +="<td>Normal:</td>";
 		html +="<td>"+getNormalEffective(i).toFixed(2)+"x</td>";
 		html +="<td style='width:50%'>";
 		for( var j = 0; j<player.normalEffectiveTypeBonus[i]; j++){
-			html += "<div <div style='background-color:#" + typeColorUnlocked[i] + "' class='col-sm-1 shardUpgrade'></div>";
+			html += "<div style='background-color:#" + typeColorUnlocked[i] + "' class='col-sm-1 shardUpgrade'></div>";
 		}
 		for(var j = player.normalEffectiveTypeBonus[i]; j<10; j++){
-			html += "<div <div style='background-color:#" + typeColorLocked[i] + "' class='col-sm-1 shardUpgrade shardUpgradeLocked'></div>";
+			html += "<div style='background-color:#" + typeColorLocked[i] + "' class='col-sm-1 shardUpgrade shardUpgradeLocked'></div>";
 		}
 		
-		html += "<td class='shardColumn4'>";
+		html += "</td><td class='shardColumn4'>";
 		if (player.normalEffectiveTypeBonus[i] < 10){
-			html += "<button class='tooltipShard' title='" + numberWithCommas(250*(player.normalEffectiveTypeBonus[i]+1)) + " " + numberToType[i] + " shards' onclick='buyUpgrade("+ i + "," + 2 +")'>Upgrade</button>";
+			var cost = 250*(player.normalEffectiveTypeBonus[i]+1);
+			if (player.typeShards[i] >= cost) {
+				html += "<button class='tooltipShard' title='" + numberWithCommas(cost) + " " + numberToType[i] + " shards' onclick='buyUpgrade("+ i + "," + 2 +")'>Upgrade</button>";
+			} else {
+				html += "<button class='tooltipShard' title='" + numberWithCommas(cost) + " " + numberToType[i] + " shards' onclick='buyUpgrade("+ i + "," + 2 +")' disabled>Upgrade</button>";
+			}
 		} else {
 			html += "<button class='disabled'>Upgrade</button>";
 		}
-		html += "</td></td></tr>";
+		html += "</td></tr>";
 
 
 		html +="<tr><td></td>";
@@ -317,19 +327,24 @@ var showShardModal = function(){
 		html +="<td>"+getVeryEffective(i).toFixed(2)+"x</td>";
 		html +="<td style='width:50%'>";
 		for( var j = 0; j<player.veryEffectiveTypeBonus[i]; j++){
-			html += "<div <div style='background-color:#" + typeColorUnlocked[i] + "' class='col-sm-1 shardUpgrade'></div>";
+			html += "<div style='background-color:#" + typeColorUnlocked[i] + "' class='col-sm-1 shardUpgrade'></div>";
 		}
 		for(var j = player.veryEffectiveTypeBonus[i]; j<10; j++){
-			html += "<div <div style='background-color:#" + typeColorLocked[i] + "' class='col-sm-1 shardUpgrade shardUpgradeLocked'></div>";
+			html += "<div style='background-color:#" + typeColorLocked[i] + "' class='col-sm-1 shardUpgrade shardUpgradeLocked'></div>";
 		}
 		
-		html += "<td class='shardColumn4'>";
+		html += "</td><td class='shardColumn4'>";
 		if (player.veryEffectiveTypeBonus[i] < 10){
-			html += "<button class='tooltipShard' title='" + numberWithCommas(250*(player.veryEffectiveTypeBonus[i]+1)) + " " + numberToType[i] + " shards' onclick='buyUpgrade("+ i + "," + 3 +")'>Upgrade</button>";
+			var cost = 250*(player.veryEffectiveTypeBonus[i]+1);
+			if (player.typeShards[i] >= cost) {
+				html += "<button class='tooltipShard' title='" + numberWithCommas(cost) + " " + numberToType[i] + " shards' onclick='buyUpgrade("+ i + "," + 3 +")'>Upgrade</button>";
+			} else {
+				html += "<button class='tooltipShard' title='" + numberWithCommas(cost) + " " + numberToType[i] + " shards' onclick='buyUpgrade("+ i + "," + 3 +")' disabled>Upgrade</button>";
+			}
 		} else {
 			html += "<button class='disabled'>Upgrade</button>";
 		}
-		html += "</td></td></tr>";
+		html += "</td></tr>";
 
 
 		html += "</table><br><br><br>";


### PR DESCRIPTION
A simple solution to the request posed in the reddit thread: https://www.reddit.com/r/PokeClicker/comments/5v0prn/suggestion_make_the_upgrade_buttons_in_the_shards/

This simply adds the disabled attribute to the button, since we're using the default buttons, I though keeping browser style would be the simplest and best way to solve it.

Also cleaned up some strange html artifacts in the same function.