### PR TITLE
Fix dungeon wall wrap issue

### DIFF
--- a/dungeons.js
+++ b/dungeons.js
@@ -179,12 +179,8 @@ var canMoveToRoom = function(target, size) {
         return true;
     }
     //things get a bit tricky with the wrapped "x-values".
-    if (currentDungeon.mapVisited[target-1]) {
-        return !(target % (size) == 0)
-    }
-    if (currentDungeon.mapVisited[target+1]) {
-        return !(target % (size) == (size - 1))
-    }
+    return currentDungeon.mapVisited[target-1] && (target % size != 0) ||
+        currentDungeon.mapVisited[target+1] && ((target+1) % size != 0)
 }
 
 var floodVisit = function(startPos) {


### PR DESCRIPTION
See @Aegyo comment for pictorial description of the issue. This is because the game thinks you're trying to access `map[10]` by wall-wrapping from `map[9]`, and rejects your move right away. It does not give the option to check that `map[11]` has been visited.