### PR TITLE
Randomize mine items only in places it can fit. Hence fix 0 item bug

### DIFF
--- a/mining.js
+++ b/mining.js
@@ -194,9 +194,9 @@ var loadMine = function(){
 	}
 	
 	for( var i = 0; i<player.curMine.maxItems; i++){
-		var x = getRandomCoord(player.curMine.sizeX);
-		var y = getRandomCoord(player.curMine.sizeY);
 		var item = getRandomMineItem();
+		var x = getRandomCoord(player.curMine.sizeX, item.space[0].length);
+		var y = getRandomCoord(player.curMine.sizeY, item.space.length);
 		var res = canAddReward(x,y,item)
 		if(res){
 			addReward(x,y,item);
@@ -512,8 +512,8 @@ var getRandomMineItem = function(){
 	return mineItemList[index] || mineItemList[0];
 }
 
-var getRandomCoord = function(max){
-	return Math.floor(Math.random()*(max-3)) + 1;
+var getRandomCoord = function(max, size){
+	return Math.floor(Math.random()*(max-size-1)) + 1;
 }
 
 var addReward = function(x, y, reward){


### PR DESCRIPTION
This essentially combines https://github.com/Ishadijcks/Ishadijcks.github.io/commit/3ae3c9016fd4937fbba373b62dcbeddff3a1cb12#diff-179a97f89e4d8cc0cce87781606fe8b5 and https://github.com/Ishadijcks/Ishadijcks.github.io/pull/175/files to fix the underground.

Currently, underground randomizes items between 1 and `max-3`, then checks if items can fit. As a result, some larger items are not guaranteed to fit. Some people may be very unlucky and have all 3 of their items not fit and create the "zero items bug". 

Here, we always guarantee the successful addition of the first item, by randomizing for spots that the item can fit. 

Note: this is basically the same as https://github.com/Ishadijcks/pokeclicker/commit/afaf88de369cb317cf02765d4a70eaf78a097f65#diff-c337aaee8e9ee46ce006207353a43b08 in the TypeScript rewrite.